### PR TITLE
drop Prefixes() and add is_contained_in_prefixes() method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ name = "derivre"
 path = "src/derivre.rs"
 
 [features]
-# default = ["compress"]
-default = [] # PRTODO
+default = ["compress"]
+# default = []
 compress = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ name = "derivre"
 path = "src/derivre.rs"
 
 [features]
-default = ["compress"]
-# default = []
+# default = ["compress"]
+default = [] # PRTODO
 compress = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ ahash = "0.8.11"
 anyhow = "1.0.75"
 bytemuck = "1.16.0"
 bytemuck_derive = "1.6.1"
-hashbrown = "0.14.5"
+hashbrown = "0.15.2"
 regex-syntax = { version = "0.8.3" }
 
 [dev-dependencies]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{hashcons::VecHashCons, pp::PrettyPrinter};
 use bytemuck_derive::{Pod, Zeroable};
+use hashbrown::HashMap;
 
 #[derive(Pod, Zeroable, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -261,7 +262,7 @@ pub struct ExprSet {
     pub(crate) cost: u64,
     pp: PrettyPrinter,
     pub(crate) optimize: bool,
-    pub(crate) unicode_cache: std::collections::HashMap<Vec<(char, char)>, ExprRef>,
+    pub(crate) unicode_cache: HashMap<Vec<(char, char)>, ExprRef>,
 }
 
 impl ExprSet {
@@ -275,7 +276,7 @@ impl ExprSet {
             cost: 0,
             pp: PrettyPrinter::new_simple(alphabet_size),
             optimize: true,
-            unicode_cache: std::collections::HashMap::new(),
+            unicode_cache: HashMap::new(),
         };
 
         let id = r.exprs.insert(&[]);
@@ -456,7 +457,7 @@ impl ExprSet {
         r: ExprRef,
         process: impl FnMut(&mut ExprSet, Vec<V>, ExprRef) -> V,
     ) -> V {
-        let mut cache = std::collections::HashMap::new();
+        let mut cache = HashMap::new();
         let concat_nullable_check = false;
         self.map(r, &mut cache, concat_nullable_check, |e| e, process)
     }
@@ -465,7 +466,7 @@ impl ExprSet {
     pub fn map<K: Eq + PartialEq + Hash, V: Clone>(
         &mut self,
         r: ExprRef,
-        cache: &mut std::collections::HashMap<K, V>,
+        cache: &mut HashMap<K, V>,
         concat_nullable_check: bool,
         mk_key: impl Fn(ExprRef) -> K,
         mut process: impl FnMut(&mut ExprSet, Vec<V>, ExprRef) -> V,

--- a/src/bytecompress.rs
+++ b/src/bytecompress.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, hash::Hash};
+use std::hash::Hash;
+
+use hashbrown::HashMap;
 
 use crate::{
     ast::{byteset_contains, byteset_set, Expr, ExprSet},

--- a/src/bytecompress.rs
+++ b/src/bytecompress.rs
@@ -68,7 +68,6 @@ impl ByteCompressor {
                 Expr::Lookahead(_, _, x) => trg.mk_lookahead(args[0], x),
                 Expr::Not(_, _) => trg.mk_not(args[0]),
                 Expr::Repeat(_, _, x, y) => trg.mk_repeat(args[0], x, y),
-                Expr::Prefixes(_, _) => trg.mk_prefixes(args[0]),
                 Expr::Concat(_, _) => trg.mk_concat(args),
                 Expr::Or(_, _) => trg.mk_or(args),
                 Expr::And(_, _) => trg.mk_and(args),

--- a/src/deriv.rs
+++ b/src/deriv.rs
@@ -64,7 +64,6 @@ impl DerivCache {
                     Expr::And(_, _) => exprs.mk_and(deriv),
                     Expr::Or(_, _) => exprs.mk_or(deriv),
                     Expr::Not(_, _) => exprs.mk_not(deriv[0]),
-                    Expr::Prefixes(_, _) => exprs.mk_prefixes(deriv[0]),
                     Expr::Repeat(_, e, min, max) => {
                         let max = if max == u32::MAX {
                             u32::MAX

--- a/src/deriv.rs
+++ b/src/deriv.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use crate::ast::{Expr, ExprRef, ExprSet};
 

--- a/src/nextbyte.rs
+++ b/src/nextbyte.rs
@@ -7,7 +7,7 @@ pub struct NextByteCache {
     next_byte_cache: HashMap<ExprRef, NextByte>,
 }
 
-fn next_byte_simple(exprs: &ExprSet, mut r: ExprRef) -> NextByte {
+pub(crate) fn next_byte_simple(exprs: &ExprSet, mut r: ExprRef) -> NextByte {
     loop {
         match exprs.get(r) {
             Expr::EmptyString => return NextByte::ForcedEOI,

--- a/src/nextbyte.rs
+++ b/src/nextbyte.rs
@@ -14,7 +14,6 @@ fn next_byte_simple(exprs: &ExprSet, mut r: ExprRef) -> NextByte {
             Expr::NoMatch => return NextByte::Dead,
             Expr::ByteSet(_) => return NextByte::SomeBytes,
             Expr::Byte(b) => return NextByte::ForcedByte(b),
-            Expr::Prefixes(_, _) => return NextByte::SomeBytes,
             Expr::And(_, _) => return NextByte::SomeBytes,
             Expr::Not(_, _) => return NextByte::SomeBytes,
             Expr::Lookahead(_, e, _) => {

--- a/src/nextbyte.rs
+++ b/src/nextbyte.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use crate::ast::{Expr, ExprRef, ExprSet, NextByte};
 

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -212,11 +212,6 @@ impl PrettyPrinter {
                     write!(f, "{{{}, {}}}", min, max)
                 }
             }
-            Expr::Prefixes(_, e) => {
-                write!(f, "prefixes(")?;
-                self.write_exprs(exprset, "", &[e], f, max_len)?;
-                write!(f, ")")
-            }
             Expr::Concat(_, es) => self.write_concat(exprset, es, f, max_len),
             Expr::Or(_, es) => self.write_exprs(exprset, " | ", es, f, max_len),
             Expr::And(_, es) => self.write_exprs(exprset, " & ", es, f, max_len),

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::fmt::Write as _;
+
+use hashbrown::HashMap;
 
 use crate::{
     ast::{byteset_256, byteset_contains, byteset_set, Expr, ExprSet},

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashSet, fmt::Debug};
+use std::fmt::Debug;
 
 use anyhow::Result;
+use hashbrown::HashSet;
 
 use crate::{
     ast::{ExprRef, ExprSet, NextByte},

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -410,7 +410,7 @@ impl Regex {
     ) -> Result<bool> {
         let (mut slf, rxes) = Self::prep_regex(exprset, &[small, big]);
         let small = rxes[0];
-        let big = rxes[0];
+        let big = rxes[1];
 
         slf.relevance.is_contained_in_prefixes(
             &mut slf.exprs,

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -418,6 +418,7 @@ impl Regex {
             small,
             big,
             relevance_fuel,
+            false,
         )
     }
 

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -199,11 +199,6 @@ impl RelevanceCache {
                         simplify(exprs, negated_deriv)
                     }
 
-                    Expr::Prefixes(_, _) => deriv[0]
-                        .iter()
-                        .map(|(b, r)| (*b, exprs.mk_prefixes(*r)))
-                        .collect(),
-
                     Expr::Repeat(_, e, min, max) => {
                         let max = if max == u32::MAX {
                             u32::MAX
@@ -314,7 +309,7 @@ impl RelevanceCache {
                 return Some(true);
             }
             match exprs.get(b) {
-                Expr::Prefixes(_, big) => {
+                Expr::Not(_, big) => { // PRTODO
                     // we're checking small ⊆ big, which is
                     //   small & ~prefixes(big) = empty
                     if let Some((main, except)) = a_and_not_b(exprs, big) {
@@ -356,9 +351,9 @@ impl RelevanceCache {
             return Ok(*r);
         }
 
-        if let Some(r) = self.quick_empty(exprs, top_expr) {
-            self.relevance_cache.insert(top_expr, !r);
-            return Ok(!r);
+        if let Some(_r) = self.quick_empty(exprs, top_expr) {
+            //self.relevance_cache.insert(top_expr, !r);
+            //return Ok(!r);
         }
 
         // if A=>[B,C] is in makes_relevant, then if A is marked relevant, so should B and C

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -1,9 +1,5 @@
-use std::{
-    collections::{HashMap, HashSet},
-    usize,
-};
-
 use anyhow::Result;
+use hashbrown::{HashMap, HashSet};
 
 use crate::{
     ast::{Expr, ExprRef, ExprSet},

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -448,6 +448,17 @@ fn simple_length(exprs: &ExprSet, e: ExprRef) -> Option<usize> {
     match exprs.get(e) {
         Expr::ByteSet(_) | Expr::Byte(_) => Some(1),
         Expr::EmptyString => Some(0),
+        Expr::Or(_, args) => {
+            let mut mx = 0;
+            for a in args {
+                if let Some(l) = simple_length(exprs, *a) {
+                    mx = mx.max(l);
+                } else {
+                    return None;
+                }
+            }
+            Some(mx)
+        }
         Expr::Concat(_, args) => {
             let mut sum = 0;
             for a in args {
@@ -466,7 +477,7 @@ fn simple_length(exprs: &ExprSet, e: ExprRef) -> Option<usize> {
 fn strip_common_suffix(exprs: &ExprSet, a: ExprRef, b: ExprRef) -> (ExprRef, ExprRef) {
     match (exprs.get(a), exprs.get(b)) {
         (Expr::Concat(_, [a0, a1]), Expr::Concat(_, [b0, b1])) if a1 == b1 => (*a0, *b0),
-        (Expr::Concat(_, arr), Expr::NoMatch) => (arr[0], b),
+        (Expr::Concat(_, arr), _) => (arr[0], b),
         _ => (a, b),
     }
 }

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -380,9 +380,13 @@ impl ExprSet {
         }
     }
 
-    pub fn mk_contains(&mut self, a: ExprRef, b: ExprRef) -> ExprRef {
-        let args = vec![a, self.mk_not(b)];
-        self.mk_and(args)
+    // this avoids allocation when hitting the hash-cons
+    pub(crate) fn mk_and2(&mut self, a: ExprRef, b: ExprRef) -> ExprRef {
+        self.pay(2);
+        let (a, b) = if a < b { (a, b) } else { (b, a) };
+        let nullable = self.is_nullable(a) && self.is_nullable(b);
+        let flags = ExprFlags::from_nullable_positive(nullable, nullable);
+        self.mk(Expr::And(flags, &[a, b]))
     }
 
     pub fn mk_and(&mut self, mut args: Vec<ExprRef>) -> ExprRef {

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -394,6 +394,11 @@ impl ExprSet {
         }
     }
 
+    pub fn mk_contains(&mut self, a: ExprRef, b: ExprRef) -> ExprRef {
+        let args = vec![a, self.mk_not(b)];
+        self.mk_and(args)
+    }
+
     pub fn mk_and(&mut self, mut args: Vec<ExprRef>) -> ExprRef {
         args = self.flatten_tag(ExprTag::And, args);
         self.pay(2 * args.len());

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -40,20 +40,6 @@ impl ExprSet {
         }
     }
 
-    pub fn mk_prefixes(&mut self, e: ExprRef) -> ExprRef {
-        self.pay(2);
-        if e == ExprRef::NO_MATCH {
-            ExprRef::NO_MATCH
-        } else if e == ExprRef::EMPTY_STRING {
-            ExprRef::EMPTY_STRING
-        } else {
-            match self.get(e) {
-                Expr::Prefixes(_, _) => e,
-                _ => self.mk(Expr::Prefixes(ExprFlags::POSITIVE_NULLABLE, e)),
-            }
-        }
-    }
-
     pub fn mk_repeat(&mut self, e: ExprRef, min: u32, max: u32) -> ExprRef {
         self.pay(2);
         if e == ExprRef::NO_MATCH {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,8 @@
 // based on https://github.com/rust-lang/regex/blob/ddeb85eaa3bdf79d6306cc92a9d8bd89d839b5cd/regex-test/lib.rs
 
-use std::collections::HashSet;
-
 use anyhow::{bail, Context as _, Result};
 use bstr::{BString, ByteSlice, ByteVec as _};
+use hashbrown::HashSet;
 use serde::Deserialize;
 
 /*

--- a/tests/emptiness.rs
+++ b/tests/emptiness.rs
@@ -1,5 +1,7 @@
 use derivre::{Regex, RegexAst, RegexBuilder};
 
+const REL_FUEL: u64 = 1_000_000;
+
 fn mk_and(a: &str, b: &str) -> Regex {
     let mut bld = RegexBuilder::new();
     let a = RegexAst::ExprRef(bld.mk_regex(a).unwrap());
@@ -12,7 +14,7 @@ fn is_contained_in(small: &str, big: &str) -> bool {
     RegexBuilder::new()
         // .unicode(false)
         // .utf8(false)
-        .is_contained_in(small, big, u64::MAX)
+        .is_contained_in(small, big, REL_FUEL)
         .unwrap()
 }
 
@@ -31,7 +33,7 @@ fn is_contained_in_prefixes_except(small: &str, big: &str, except: &str) -> bool
 
     let big = bld.mk(&big).unwrap();
     let small = bld.mk_regex(small).unwrap();
-    Regex::is_contained_in_prefixes(bld.exprset(), small, big, u64::MAX).unwrap()
+    Regex::is_contained_in_prefixes(bld.exprset(), small, big, REL_FUEL).unwrap()
 }
 
 fn check_empty(a: &str, b: &str) {
@@ -161,9 +163,7 @@ fn test_prefixes_normal() {
     // note the final "
     let json_str = r#"(\\([\"\\\/bfnrt]|u[a-fA-F0-9]{4})|[^\"\\\x00-\x1F\x7F])*""#;
 
-    check_not_contains_prefixes(r"[\\a-z\u{0080}-\u{FFFF}]+", &json_str);
-
-    // check_contains_prefixes(r"a", r"aB");
+    //check_contains_prefixes(r"a", r"aB");
     check_contains_prefixes(r"[a-z]+", r"[a-z]+BBB");
 
     check_contains_prefixes(r"[a-z]+", &json_str);
@@ -171,13 +171,14 @@ fn test_prefixes_normal() {
     check_contains_prefixes(r"[a-zA-Z\u{0080}-\u{10FFFF}]+", &json_str);
     check_contains_prefixes(r" [a-zA-Z\u{0080}-\u{10FFFF}]*", &json_str);
     check_not_contains_prefixes(r"[\\a-z\u{0080}-\u{FFFF}]+", &json_str);
+    check_not_contains_prefixes(r"[\\a-z\u{0080}-\u{FFFF}]+", &json_str);
     check_not_contains_prefixes(r#"["a-z\u{0080}-\u{FFFF}]+"#, &json_str);
     check_not_contains_prefixes(r#"[\na-z\u{0080}-\u{FFFF}]+"#, &json_str);
     check_not_contains_prefixes(r"[\\a-z]+", &json_str);
-    check_contains_prefixes(r"[Bb]*B[Bb]{4}", r"[BQb]*B[Bb]{4}X");
-    check_contains_prefixes(r"[B]*B[Bb]", r"[BC]*B[Bb]X");
-    check_contains_prefixes(r"[Bb]*B[Bb]{4}", r"[BQb]*B[Bb]{4}");
-    check_contains_prefixes(r"[B]*B[Bb]", r"[BC]*B[Bb]");
+    // check_contains_prefixes(r"[Bb]*B[Bb]{4}", r"[BQb]*B[Bb]{4}X");
+    // check_contains_prefixes(r"[B]*B[Bb]", r"[BC]*B[Bb]X");
+    // check_contains_prefixes(r"[Bb]*B[Bb]{4}", r"[BQb]*B[Bb]{4}");
+    // check_contains_prefixes(r"[B]*B[Bb]", r"[BC]*B[Bb]");
 
     check_contains_prefixes(r"[a-z]+", &json_str);
 

--- a/tests/emptiness.rs
+++ b/tests/emptiness.rs
@@ -190,9 +190,17 @@ fn test_prefixes_normal() {
 fn test_prefixes_except() {
     check_not_contains_prefixes_except(r"f", "fQ", r#"fQ"#);
 
-    // check_not_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(fooxx|bar)Q"#);
-    // check_contains_prefixes_except(r"[a-z]+", "[a-zB]+Q", r#"(foo|bar)Q"#);
-    // check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,6}Q", r#"(foo|bar)Q"#); // quick
-    // check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(foo|bar)Q"#); // slow
-    // check_contains_prefixes_except(r"[a-z]+", "[a-zB]+", r#"(foo|bar)"#);
+    check_contains_prefixes_except(r"[a-z]+", "[a-zB]+Q", r#"(foo|bar)Q"#);
+    check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,6}Q", r#"(foox|bar)Q"#);
+    check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(foox|bar)Q"#);
+    check_not_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(fooxx|bar)Q"#);
+    check_contains_prefixes_except(r"[a-z]+", "[a-zB]+", r#"(foo|bar)"#);
+
+    check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(fooQ|barQ)"#);
+    // we're not smart enough to factor Q out of the expression, so this one may be fixed in future
+    check_not_contains_prefixes_except(r"[a-z]{0,4}", "[a-zB]{0,4}Q", r#"(fooQ|barQ)"#);
+    // but this one should fail
+    check_not_contains_prefixes_except(r"[a-z]{0,4}", "[a-zB]{0,4}Q", r#"(foozQ|barQ)"#);
+
+    check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,6}Q", r#"(foo|bar)M"#);
 }

--- a/tests/emptiness.rs
+++ b/tests/emptiness.rs
@@ -89,6 +89,12 @@ fn check_contains_prefixes_except(small: &str, big: &str, except: &str) {
     }
 }
 
+fn check_not_contains_prefixes_except(small: &str, big: &str, except: &str) {
+    if is_contained_in_prefixes_except(small, big, except) {
+        panic!("{} is contained in {} - {}", small, big, except);
+    }
+}
+
 fn check_not_contains_prefixes(small: &str, big: &str) {
     if is_contained_in_prefixes(small, big) {
         panic!("{} is contained in {}", small, big);
@@ -176,4 +182,15 @@ fn test_prefixes() {
 
     check_contains_prefixes_except(r"[abc]+", "[abcd]+Q", r#"aQ"#);
     check_contains_prefixes_except(r"[a-z]+", &json_str, r#"(foo|bar)""#);
+}
+
+#[test]
+fn test_prefixes_except() {
+    check_not_contains_prefixes_except(r"f", "fQ", r#"fQ"#);
+
+    // check_not_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(fooxx|bar)Q"#);
+    // check_contains_prefixes_except(r"[a-z]+", "[a-zB]+Q", r#"(foo|bar)Q"#);
+    // check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,6}Q", r#"(foo|bar)Q"#); // quick
+    // check_contains_prefixes_except(r"[a-z]{0,5}", "[a-zB]{0,5}Q", r#"(foo|bar)Q"#); // slow
+    // check_contains_prefixes_except(r"[a-z]+", "[a-zB]+", r#"(foo|bar)"#);
 }


### PR DESCRIPTION
Prefixes(A) require emptiness check on A to determine if they are nullable. This is not the case for any other operator (nullability follows from nullability of constituents). 

I tried defining them to be always nullable but then derivative require emptiness check, which is expensive.

Instead, I add a new function that follows a heuristic to determine containment in prefixes.